### PR TITLE
Add png support

### DIFF
--- a/bin/emmaze.py
+++ b/bin/emmaze.py
@@ -124,7 +124,7 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--output_type",
+        "--output-type",
         "-t",
         type=str,
         nargs="?",
@@ -133,7 +133,7 @@ if __name__ == "__main__":
         default="text",
     )
     parser.add_argument(
-        "--output_file",
+        "--output-file",
         "-o",
         nargs="?",
         metavar="FILE",
@@ -142,7 +142,8 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--cell_size",
+        "--cell-size",
+        "-l",
         nargs="?",
         metavar="CELLSIZE",
         type=int,
@@ -154,13 +155,25 @@ if __name__ == "__main__":
     )
 
     parser.add_argument(
-        "--wall_size",
+        "--wall-size",
+        "-w",
         nargs="?",
         metavar="WALLSIZE",
         type=int,
         default=1,
         help="thickness of the maze walls (default is 1)",
     )
+
+    parser.add_argument(
+        "--border-size",
+        "-b",
+        nargs="?",
+        metavar="BORDERSIZE",
+        type=int,
+        default=0,
+        help=("thickness of the border (default is 0)"),
+    )
+
     parser.add_argument(
         "--solutions", "-s", action="store_true", help="include solutions"
     )
@@ -192,6 +205,8 @@ if __name__ == "__main__":
             raise ValueError("Invalid cell size; must be a positive integer.")
         if args["wall_size"] < 1:
             raise ValueError("Invalid wall size; must be a positive integer.")
+        if args["border_size"] < 0:
+            raise ValueError("Invalid border size; must be a nonnegative integer.")
         maze: mz.Maze
         maze_exits: list[mz.MazeExit]
         solns: list[solutions.MazePath] = []
@@ -229,7 +244,10 @@ if __name__ == "__main__":
             else:
                 cell_size = args["cell_size"]
             maze_text = maze.str_version(
-                WALL_CHARACTER_DICT[args["output_type"]], cell_size, args["wall_size"]
+                WALL_CHARACTER_DICT[args["output_type"]],
+                cell_size,
+                args["wall_size"],
+                args["border_size"],
             )
             if args["solutions"]:
                 solution_text = maze_text
@@ -273,7 +291,9 @@ if __name__ == "__main__":
             else:
                 cell_size = args["cell_size"]
             with open(args["output_file"], "wb") as svgfile:
-                maze.make_png(svgfile, cell_size, args["wall_size"])
+                maze.make_png(
+                    svgfile, cell_size, args["wall_size"], args["border_size"]
+                )
         else:
             with open(args["output_file"], "wt") as outfile:
                 outfile.write(maze_text)

--- a/bin/emmaze.py
+++ b/bin/emmaze.py
@@ -29,6 +29,7 @@ import argparse
 from typing import Final
 
 import emmaze.maze as mz
+import emmaze.pngmazes as pngmazes
 import emmaze.solutions as solutions
 import emmaze.svgmazes as svgmazes
 from emmaze.jsonsupport import json_to_maze, maze_to_json
@@ -252,7 +253,12 @@ if __name__ == "__main__":
             if args["solutions"]:
                 solution_text = maze_text
                 for mp in solns:
-                    solution_text = mp.append_text_solution(solution_text)
+                    solution_text = mp.append_text_solution(
+                        solution_text,
+                        cell_size=cell_size,
+                        wall_size=args["wall_size"],
+                        border_size=args["border_size"],
+                    )
 
         elif args["output_type"] == "svg":
             if args["cell_size"] == -1:
@@ -290,9 +296,21 @@ if __name__ == "__main__":
                 cell_size = 1
             else:
                 cell_size = args["cell_size"]
-            with open(args["output_file"], "wb") as svgfile:
-                maze.make_png(
-                    svgfile, cell_size, args["wall_size"], args["border_size"]
+            maze_text = pngmazes.maze_png(
+                maze,
+                args["output_file"],
+                cell_size,
+                args["wall_size"],
+                args["border_size"],
+            )
+            if args["solutions"]:
+                pngmazes.soln_png(
+                    f"solution_{args['output_file']}",
+                    maze_solns=solns,
+                    maze_str=maze_text,
+                    cell_size=cell_size,
+                    wall_size=args["wall_size"],
+                    border_size=args["border_size"],
                 )
         else:
             with open(args["output_file"], "wt") as outfile:

--- a/docs/source/API_reference.rst
+++ b/docs/source/API_reference.rst
@@ -70,6 +70,12 @@ Functions
 
 .. autofunction:: make_maze
 
+``pngmazes``: Functionality to output mazes in PNG format
+=========================================================
+
+.. automodule:: emmaze.pngmazes
+   :members:
+
 
 ``solutions``: Solve mazes and display solutions
 ================================================

--- a/emmaze/maze.py
+++ b/emmaze/maze.py
@@ -26,11 +26,8 @@ from __future__ import annotations
 
 from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass
-from io import BufferedWriter
 from random import choice, random, sample
 from typing import Final, Generic, Literal, Optional, TypeAlias, TypeVar
-
-import png  # type: ignore
 
 T = TypeVar("T")
 
@@ -97,11 +94,14 @@ class Position:
             return "NS", self.row, self.column
 
     def text_location(
-        self: Position, cell_size: int = 1, wall_size: int = 1
+        self: Position, cell_size: int = 1, wall_size: int = 1, border_size: int = 0
     ) -> tuple[int, int]:
         """Return character position for an text-art maze."""
         total_size = cell_size + wall_size
-        return total_size * self.column + wall_size, total_size * self.row + wall_size
+        return (
+            total_size * self.column + wall_size + border_size + cell_size // 2,
+            total_size * self.row + wall_size + border_size + cell_size // 2,
+        )
 
 
 @dataclass
@@ -507,40 +507,6 @@ class Maze:
     def __str__(self: Maze) -> str:
         """Return ``str(self)``."""
         return self.str_version()
-
-    def make_png(
-        self: Maze,
-        f: BufferedWriter,
-        cell_size: int = 1,
-        wall_size: int = 1,
-        border_size: int = 0,
-    ) -> None:
-        """
-        Write a PNG version of the maze to a file.
-
-        :param f: A file object in which to write the PNG.
-        :type f: io.TextIOWrapper
-
-        :param cell_size: The length and width of each cell in pixels, defaults to 1.
-        :type cell_size: int
-
-        :param wall_size: The thickness of each wall in pixels, defaults to 1.
-        :type wall_size: int
-
-        :param border_size: The thickness of the border in pixels, defaults to 0.
-        :type border_size: int
-        """
-        total_size = cell_size + wall_size
-        bitmap = [
-            [int(col) for col in row]
-            for row in self.str_version("0", cell_size, wall_size, border_size)
-            .replace(" ", "1")
-            .split("\n")
-        ]
-        width = self.cols * total_size + wall_size + 2 * border_size
-        height = self.rows * total_size + wall_size + 2 * border_size
-        writer = png.Writer(width, height, greyscale=True, bitdepth=1)
-        writer.write(f, bitmap)
 
 
 class MazeConstructor:

--- a/emmaze/maze.py
+++ b/emmaze/maze.py
@@ -453,8 +453,8 @@ class Maze:
         (3, 0) to (6, 3), etc.
         """
         total_cell_size = cell_size + wall_size
-        if (x < 0 or x > total_cell_size * self.cols + wall_size) or (
-            y < 0 or y > total_cell_size * self.rows + wall_size
+        if (x < 0 or x >= total_cell_size * self.cols + wall_size) or (
+            y < 0 or y >= total_cell_size * self.rows + wall_size
         ):
             return False
         if x % total_cell_size < wall_size and y % total_cell_size < wall_size:
@@ -466,7 +466,11 @@ class Maze:
         return False
 
     def str_version(
-        self: Maze, wall_chr: str = "#", cell_size: int = 1, wall_size: int = 1
+        self: Maze,
+        wall_chr: str = "#",
+        cell_size: int = 1,
+        wall_size: int = 1,
+        border_size: int = 0,
     ) -> str:
         """
         Return ASCII art version of the maze.
@@ -483,16 +487,21 @@ class Maze:
         :param wall_size: Thickness of walls in characters, defaults to 1.
         :type wall_size: int
 
+        :param border_size: Thickness of the border, defaults to 0.
+        :type border_size: int
+
         :returns: An ASCII-art version of the maze.
         :rtype: str
         """
         total_size = cell_size + wall_size
         return "\n".join(
             "".join(
-                wall_chr if self.solid(x, y, cell_size, wall_size) else " "
-                for x in range(total_size * self.cols + wall_size)
+                wall_chr
+                if self.solid(x - border_size, y - border_size, cell_size, wall_size)
+                else " "
+                for x in range(total_size * self.cols + wall_size + 2 * border_size)
             )
-            for y in range(total_size * self.rows + wall_size)
+            for y in range(total_size * self.rows + wall_size + 2 * border_size)
         )
 
     def __str__(self: Maze) -> str:
@@ -500,7 +509,11 @@ class Maze:
         return self.str_version()
 
     def make_png(
-        self: Maze, f: BufferedWriter, cell_size: int = 1, wall_size: int = 1
+        self: Maze,
+        f: BufferedWriter,
+        cell_size: int = 1,
+        wall_size: int = 1,
+        border_size: int = 0,
     ) -> None:
         """
         Write a PNG version of the maze to a file.
@@ -513,16 +526,19 @@ class Maze:
 
         :param wall_size: The thickness of each wall in pixels, defaults to 1.
         :type wall_size: int
+
+        :param border_size: The thickness of the border in pixels, defaults to 0.
+        :type border_size: int
         """
         total_size = cell_size + wall_size
         bitmap = [
             [int(col) for col in row]
-            for row in self.str_version("0", cell_size, wall_size)
+            for row in self.str_version("0", cell_size, wall_size, border_size)
             .replace(" ", "1")
             .split("\n")
         ]
-        width = self.cols * total_size + wall_size
-        height = self.rows * total_size + wall_size
+        width = self.cols * total_size + wall_size + 2 * border_size
+        height = self.rows * total_size + wall_size + 2 * border_size
         writer = png.Writer(width, height, greyscale=True, bitdepth=1)
         writer.write(f, bitmap)
 

--- a/emmaze/pngmazes.py
+++ b/emmaze/pngmazes.py
@@ -1,0 +1,245 @@
+"""Functions to output mazes as pngs."""
+
+# MIT License
+#
+# Copyright (c) 2022 Christopher L. Phan
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from io import BufferedWriter
+from typing import Optional
+
+import png  # type: ignore
+
+import emmaze.maze as mz
+import emmaze.solutions as solns
+
+
+def _make_maze_png(
+    str_version: str,
+    f: BufferedWriter,
+    wall_char: str = "#",
+    step_char: str = "+",
+    include_solution: bool = False,
+    cell_color: tuple[int, int, int] = (0xFF, 0xFF, 0xFF),
+    wall_color: tuple[int, int, int] = (0, 0, 0),
+    soln_color: tuple[int, int, int] = (0xFF, 0x00, 0x00),
+) -> None:
+    """
+    Write a PNG version of the maze to a file from the string provided by maze.str_version.
+
+    :param str_version: The string version of the maze from maze.str_version
+    :type str_version: str
+
+    :param f: A file object in which to write the PNG.
+    :type f: io.BufferedWriter
+
+    :param wall_char: The character that represents the walls, default is "#"
+    :type wall_char: str
+
+    :param step_char: The character that represents the solution, default is "+"
+    :type step_char: str
+
+    :param include_solution: Set to ``True`` if the solution path is to be included
+                             (assuming the string has the solution),
+                             ``False`` otherwise.
+    :type include_solution: bool
+
+    :param cell_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0xff, 0xff, 0xff)``.
+    :type cell_color: tuple[int, int, int]
+
+    :param wall_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0, 0, 0)``.
+    :type wall_color: tuple[int, int, int]
+
+    :param soln_color: The color to make the solution path in the PNG, as an RGB tuple,
+                       defaults to ``(0xff, 0, 0).
+    :type soln_color: tuple[int, int, int]
+    """
+    palette = [
+        cell_color,
+        soln_color if include_solution else cell_color,
+        wall_color,
+        cell_color,
+    ]
+    bitmap = [
+        [int(col) for col in row]
+        for row in str_version.replace(wall_char, "0")
+        .replace(" ", "2")
+        .replace(step_char, "1")
+        .split("\n")
+    ]
+    width = len(bitmap)
+    height = len(bitmap[0])
+    writer = png.Writer(width, height, palette=palette, bitdepth=2)
+    writer.write(f, bitmap)
+
+
+def maze_png(
+    maze: mz.Maze,
+    filename: str,
+    cell_size: int = 1,
+    wall_size: int = 1,
+    border_size: int = 0,
+    cell_color: tuple[int, int, int] = (0, 0, 0),
+    wall_color: tuple[int, int, int] = (0xFF, 0xFF, 0xFF),
+) -> str:
+    """
+    Write a PNG version of the maze to a file.
+
+    The function returns a string version of the maze, for possible use in the
+    `soln_png` function later.
+
+    :param maze: The maze to draw in the PNG file.
+    :type maze: emmaze.maze.Maze
+
+    :param filename: The filename in which to write the PNG
+    :type filename: str
+
+    :param cell_size: Width and height of cells (not counting walls) in pixels,
+                      defaults to 1.
+    :type cell_size: int
+
+    :param wall_size: Thickness of walls in pixels, defaults to 1.
+    :type wall_size: int
+
+    :param border_size: Thickness of the border, defaults to 0.
+    :type border_size: int
+
+    :param cell_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0xff, 0xff, 0xff)``.
+    :type cell_color: tuple[int, int, int]
+
+    :param wall_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0, 0, 0)``.
+    :type wall_color: tuple[int, int, int]
+
+    :returns: The text-art version of the maze
+    :rtype: str
+    """
+    maze_str = maze.str_version(
+        cell_size=cell_size, wall_size=wall_size, border_size=border_size
+    )
+    with open(filename, "wb") as outfile:
+        _make_maze_png(
+            maze_str,
+            outfile,
+            cell_color=cell_color,
+            wall_color=wall_color,
+        )
+    return maze_str
+
+
+def soln_png(
+    filename: str,
+    maze: Optional[mz.Maze] = None,
+    maze_solns: Optional[Collection[solns.MazePath]] = None,
+    maze_str: Optional[str] = None,
+    wall_char: str = "#",
+    cell_size: int = 1,
+    wall_size: int = 1,
+    border_size: int = 0,
+    cell_color: tuple[int, int, int] = (0, 0, 0),
+    wall_color: tuple[int, int, int] = (0xFF, 0xFF, 0xFF),
+    soln_color: tuple[int, int, int] = (0xFF, 0, 0),
+) -> None:
+    """
+    Write a PNG of the maze solution to a file.
+
+    :param filename: The name of the file to which to write the PNG
+    :type: str
+
+    :param maze: The maze for which a solution is desired. This may be omitted if the
+                 solution and string version of the maze are provided.
+    :type Maze: Optional[emmaze.maze.Maze]
+
+    :param maze_solns: The solutions for the maze. If ommitted and ``maze`` is provided,
+                       then the solutions will be generated.
+    :type maze_solns: Optional[Collection[emmaze.Solutions.MazePath]]
+
+    :param maze_str: A pre-generated string for the maze. If omitted and ``maze`` is
+                     provided, then the string will be generated.
+    :type maze_str: str
+
+    :param wall_char: The character that represents the walls, default is "#". (Only
+                      used if ``maze_str`` is provided, to decode the string, otherwise
+                      ignored.)
+    :type wall_char: str
+
+    :param cell_size: Width and height of cells (not counting walls) in pixels,
+                      defaults to 1.
+    :type cell_size: int
+
+    :param wall_size: Thickness of walls in pixels, defaults to 1.
+    :type wall_size: int
+
+    :param border_size: Thickness of the border, defaults to 0.
+    :type border_size: int
+
+    :param cell_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0xff, 0xff, 0xff)``.
+    :type cell_color: tuple[int, int, int]
+
+    :param wall_color: The color to make the walls in the PNG, as an RGB tuple, defaults
+                       to ``(0, 0, 0)``.
+    :type wall_color: tuple[int, int, int]
+
+    :param soln_color: The color to make the solution path in the PNG, as an RGB tuple,
+                       defaults to ``(0xff, 0, 0)``.
+    :type soln_color: tuple[int, int, int]
+    """
+    if maze_str is None:
+        if maze is None:
+            raise ValueError("Must provide a maze string or maze.")
+        else:
+            maze_str = maze.str_version(
+                cell_size=cell_size, wall_size=wall_size, border_size=border_size
+            )
+            wall_char = "#"
+    if maze_solns is None:
+        if maze is None:
+            raise ValueError("Must provide a maze solution or maze.")
+        else:
+            if len(maze.exits) < 2:
+                raise ValueError("Need at least two exits.")
+            maze_solvers = [
+                solns.MazeSolver(
+                    maze, start.cell_position(maze), end.cell_position(maze)
+                )
+                for start, end in zip(maze.exits[:-1], maze.exits[1:])
+            ]
+            maze_solns = [solver.run() for solver in maze_solvers]
+    for mp in maze_solns:
+        maze_str = mp.append_text_solution(
+            maze_str, cell_size=cell_size, wall_size=wall_size, border_size=border_size
+        )
+    with open(filename, "wb") as outfile:
+        _make_maze_png(
+            maze_str,
+            outfile,
+            wall_char,
+            include_solution=True,
+            cell_color=cell_color,
+            wall_color=wall_color,
+            soln_color=soln_color,
+        )

--- a/emmaze/solutions.py
+++ b/emmaze/solutions.py
@@ -43,15 +43,20 @@ def _make_text_step_range(start: int, end: int, include_end: bool) -> range:
 
 
 def _text_step(
-    start: mz.Position, end: mz.Position, include_end: bool = False
+    start: mz.Position,
+    end: mz.Position,
+    include_end: bool = False,
+    cell_size: int = 1,
+    wall_size: int = 1,
+    border_size: int = 0,
 ) -> list[tuple[int, int]]:
     """
     Return the characters that represent the steps between two positions.
 
     The positions must be in the same row or column.
     """
-    initial = start.text_location
-    final = end.text_location
+    initial = start.text_location(cell_size, wall_size, border_size)
+    final = end.text_location(cell_size, wall_size, border_size)
     if all(a != b for a, b in zip(initial, final)):
         raise ValueError("Not in the same row or same column.")
     if initial[0] == final[0]:  # same column
@@ -101,17 +106,28 @@ class MazePath:
         svg.interior.append(self.svg_path(maze, width, height, offset, dashpattern))
 
     def append_text_solution(
-        self: MazePath, maze_str: str, step_char: str = "+"
+        self: MazePath,
+        maze_str: str,
+        step_char: str = "+",
+        cell_size: int = 1,
+        wall_size: int = 1,
+        border_size: int = 0,
     ) -> str:
         """Append path to a text version of the maze."""
         text_path: list[tuple[int, int]] = sum(
             (
-                _text_step(start, end)
+                _text_step(
+                    start,
+                    end,
+                    cell_size=cell_size,
+                    wall_size=wall_size,
+                    border_size=border_size,
+                )
                 for start, end in zip(self.path[:-1], self.path[1:])
             ),
             start=[],
         ) + [  # type: ignore
-            self.path[-1].text_location
+            self.path[-1].text_location(cell_size, wall_size, border_size)
         ]
         text_version = maze_str.split("\n")
         for a, b in text_path:
@@ -232,8 +248,15 @@ class MazeSolver:
         path.add_path_to_svg(self.maze, width, height, svg, offset, dashpattern)
 
     def append_text_solution(
-        self: MazeSolver, maze_str: str, step_char: str = "+"
+        self: MazeSolver,
+        maze_str: str,
+        step_char: str = "+",
+        cell_size: int = 1,
+        wall_size: int = 1,
+        border_size: int = 0,
     ) -> str:
         """Append solution to a text version of the maze."""
         path: MazePath = self.run()
-        return path.append_text_solution(maze_str, step_char)
+        return path.append_text_solution(
+            maze_str, step_char, cell_size, wall_size, border_size
+        )


### PR DESCRIPTION
Add support to output to PNG. This is necessary because large mazes (e.g. 200 &times; 200) can generate very big SVG files.